### PR TITLE
Add negative and zero tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-text\npytest==8.2.0\n
+pytest==8.2.0

--- a/src/calc.py
+++ b/src/calc.py
@@ -1,1 +1,6 @@
-python\ndef add(a: int, b: int) -> int:\n \"\"\"Return the **sum** of two integers.\"\"\"\n return a - b # ← わざとバグ\n
+from __future__ import annotations
+
+
+def add(a: int, b: int) -> int:
+    """Return the **sum** of two integers."""
+    return a + b

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,1 +1,15 @@
-python\nfrom src.calc import add\n\ndef test_add():\n assert add(2, 3) == 5\n
+import pytest
+
+from src.calc import add
+
+
+def test_add():
+    assert add(2, 3) == 5
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [(-1, -2, -3), (-1, 1, 0), (0, 0, 0)],
+)
+def test_add_negative(a: int, b: int, expected: int) -> None:
+    assert add(a, b) == expected


### PR DESCRIPTION
## Summary
- fix `calc.add` bug and drop stray prefix characters
- update requirements file format
- extend `tests/test_calc.py` with cases for negatives and zero

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684121d93538832984f71b0d0c38f487