### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff mypy
+          pip install -r requirements.txt
+      - name: Ruff
+        run: ruff check .
+      - name: Mypy
+        run: mypy src tests
+      - name: Pytest
+        run: pytest -q

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -1,4 +1,12 @@
+"""Test module for calc utilities."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from src.calc import add
+
 
 def test_add():
     assert add(2, 3) == 5


### PR DESCRIPTION
## Summary
- tests ファイルのインポートパスを修正
- Python3.11 で ruff→mypy→pytest を実行する CI を追加

## Testing
- `ruff check .`
- `black .`
- `mypy src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841266f8d388329ae1a881d32e9b735